### PR TITLE
docs: Phare integration

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -243,16 +243,16 @@ You can use the buttons to provide updates. The message will be updated indicati
 
 ![Statuspage final update](./assets/statuspage_final_update.png){: style="width:600px"}
 
-## Phare
+## Phare Uptime
 
-You can integrate with [Phare](https://phare.io) to automatically prompt for Phare incident creation when a new incident is declared. Incidents can be created, updated, and recovered directly from Slack.
+You can integrate with [Phare Uptime](https://phare.io) to automatically prompt for Phare Uptime incident creation when a new incident is declared. Incidents can be created, updated, and recovered directly from Slack.
 
 Provide the following environment variables:
 
 - `PHARE_API_KEY` - Phare API key.
 - `PHARE_PROJECT_ID` - *(Optional)* Phare project ID. Required when using an organization-scoped API key.
 
-### Configuring the Phare Integration
+### Configuring the Phare Uptime Integration
 
 In the application's `config.yaml`, add a `phare` section under `integrations`:
 
@@ -277,21 +277,21 @@ integrations:
         - sre-team
 ```
 
-### Using the Phare Integration
+### Using the Phare Uptime Integration
 
-With the integration enabled, a prompt will appear in the incident channel when a new incident is declared. Click **Start Phare Incident** to open the creation modal.
+With the integration enabled, a prompt will appear in the incident channel when a new incident is declared. Click **Start Phare Uptime Incident** to open the creation modal.
 
 The modal allows you to set a title, description, impact level, and select affected monitors. Monitors are fetched live from the Phare API — no configuration required.
 
 !!! note "Multiple status pages"
 
-    Phare does not expose a status page selector on the incident API. Which status pages display an incident is determined entirely by monitor selection: each status page is configured with components that reference specific monitors, so selecting a monitor automatically surfaces the incident on any status page that includes it as a component.
+    Phare Uptime does not expose a status page selector on the incident API. Which status pages display an incident is determined entirely by monitor selection: each status page is configured with components that reference specific monitors, so selecting a monitor automatically surfaces the incident on any status page that includes it as a component.
 
 Once created, a management message appears in the channel showing the current state and a log of updates. Use the **Update Incident** button to post updates or resolve the incident.
 
 !!! note
 
-    Resolving an incident calls Phare's dedicated recovery endpoint (`POST /uptime/incidents/{id}/recover`) rather than posting a state update.
+    Resolving an incident calls Phare Uptime's dedicated recovery endpoint (`POST /uptime/incidents/{id}/recover`) rather than posting a state update.
 
 ## PagerDuty
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -285,6 +285,10 @@ With the integration enabled, a prompt will appear in the incident channel when 
 
 The modal allows you to set a title, description, impact level, and select affected monitors. Monitors are fetched live from the Phare API — no configuration required.
 
+!!! note "Multiple status pages"
+
+    Phare does not expose a status page selector on the incident API. Which status pages display an incident is determined entirely by monitor selection: each status page is configured with components that reference specific monitors, so selecting a monitor automatically surfaces the incident on any status page that includes it as a component.
+
 Once created, a management message appears in the channel showing the current state and a log of updates. Use the **Update Incident** button to post updates or resolve the incident.
 
 !!! note

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -243,6 +243,54 @@ You can use the buttons to provide updates. The message will be updated indicati
 
 ![Statuspage final update](./assets/statuspage_final_update.png){: style="width:600px"}
 
+## Phare
+
+You can integrate with [Phare](https://phare.io) to automatically prompt for Phare incident creation when a new incident is declared. Incidents can be created, updated, and recovered directly from Slack.
+
+Provide the following environment variables:
+
+- `PHARE_API_KEY` - Phare API key.
+- `PHARE_PROJECT_ID` - *(Optional)* Phare project ID. Required when using an organization-scoped API key.
+
+### Configuring the Phare Integration
+
+In the application's `config.yaml`, add a `phare` section under `integrations`:
+
+!!! warning
+
+    `PHARE_API_KEY` must be set for the integration to start. All other values have defaults.
+
+```yaml
+integrations:
+  phare:
+    enabled: true
+    url: https://phare.io
+```
+
+You can optionally restrict who can create and manage Phare incidents from Slack by adding Slack group names under `permissions.groups`. Anyone not in one of these groups will receive an ephemeral message indicating they lack the required permissions.
+
+```yaml
+integrations:
+  phare:
+    enabled: true
+    url: https://phare.io
+    permissions:
+      groups:
+        - sre-team
+```
+
+### Using the Phare Integration
+
+With the integration enabled, a prompt will appear in the incident channel when a new incident is declared. Click **Start Phare Incident** to open the creation modal.
+
+The modal allows you to set a title, description, impact level, and select affected monitors. Monitors are fetched live from the Phare API — no configuration required.
+
+Once created, a management message appears in the channel showing the current state and a log of updates. Use the **Update Incident** button to post updates or resolve the incident.
+
+!!! note
+
+    Resolving an incident calls Phare's dedicated recovery endpoint (`POST /uptime/incidents/{id}/recover`) rather than posting a state update.
+
 ## PagerDuty
 
 You can integrate with PagerDuty to issue pages to teams. Set the following environment variables:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -264,7 +264,6 @@ In the application's `config.yaml`, add a `phare` section under `integrations`:
 integrations:
   phare:
     enabled: true
-    url: https://phare.io
 ```
 
 You can optionally restrict who can create and manage Phare incidents from Slack by adding Slack group names under `permissions.groups`. Anyone not in one of these groups will receive an ephemeral message indicating they lack the required permissions.
@@ -273,7 +272,6 @@ You can optionally restrict who can create and manage Phare incidents from Slack
 integrations:
   phare:
     enabled: true
-    url: https://phare.io
     permissions:
       groups:
         - sre-team


### PR DESCRIPTION
Adds documentation for the Phare status-page integration introduced in https://github.com/incidentbot/incidentbot/pull/766